### PR TITLE
Add failed dataset integrity check message

### DIFF
--- a/torchmeta/datasets/cifar100/base.py
+++ b/torchmeta/datasets/cifar100/base.py
@@ -45,7 +45,7 @@ class CIFAR100ClassDataset(ClassDataset):
             self.download()
 
         if not self._check_integrity():
-            raise RuntimeError()
+            raise RuntimeError('CIFAR100 integrity check failed')
         self._num_classes = len(self.labels)
 
     def __getitem__(self, index):

--- a/torchmeta/datasets/miniimagenet.py
+++ b/torchmeta/datasets/miniimagenet.py
@@ -124,7 +124,7 @@ class MiniImagenetClassDataset(ClassDataset):
             self.download()
 
         if not self._check_integrity():
-            raise RuntimeError()
+            raise RuntimeError('MiniImagenet integrity check failed')
         self._num_classes = len(self.labels)
 
     def __getitem__(self, index):

--- a/torchmeta/datasets/omniglot.py
+++ b/torchmeta/datasets/omniglot.py
@@ -143,7 +143,7 @@ class OmniglotClassDataset(ClassDataset):
             self.download()
 
         if not self._check_integrity():
-            raise RuntimeError()
+            raise RuntimeError('Omniglot integrity check failed')
         self._num_classes = len(self.labels)
 
     def __getitem__(self, index):

--- a/torchmeta/datasets/tieredimagenet.py
+++ b/torchmeta/datasets/tieredimagenet.py
@@ -127,7 +127,7 @@ class TieredImagenetClassDataset(ClassDataset):
             self.download()
 
         if not self._check_integrity():
-            raise RuntimeError()
+            raise RuntimeError('TieredImagenet integrity check failed')
         self._num_classes = len(self.labels_specific)
 
     @property


### PR DESCRIPTION
First of all, thanks for the great library. I intend to use it for a research project, and it will be help me a lot.

The PR in itself is something minor: I tried to run the example without setting the `download` flag, and it crashed with an empty `RuntimeError` exception. So I thought adding a small message informing the error's reason would be more helpful.