### PR TITLE
Use a well-behaved default target_transform for default_collate

### DIFF
--- a/torchmeta/transforms/__init__.py
+++ b/torchmeta/transforms/__init__.py
@@ -1,3 +1,4 @@
 from torchmeta.transforms.categorical import Categorical, FixedCategory
 from torchmeta.transforms.augmentations import Rotation, HorizontalFlip, VerticalFlip
 from torchmeta.transforms.splitters import Splitter, ClassSplitter, WeightedClassSplitter
+from torchmeta.transforms.target_transforms import TargetTransform, DefaultTargetTransform

--- a/torchmeta/transforms/categorical.py
+++ b/torchmeta/transforms/categorical.py
@@ -2,8 +2,10 @@ import torch
 from torchmeta.transforms.utils import apply_wrapper
 from collections import defaultdict
 
+from torchmeta.transforms.target_transforms import TargetTransform
 
-class Categorical(object):
+
+class Categorical(TargetTransform):
     """Target transform to return labels in `[0, num_classes)`.
 
     Parameters
@@ -27,6 +29,7 @@ class Categorical(object):
     (<PIL.Image.Image image mode=L size=105x105 at 0x11ED3F668>, 2)
     """
     def __init__(self, num_classes=None):
+        super(Categorical, self).__init__()
         self.num_classes = num_classes
         self._classes = None
         self._labels = None

--- a/torchmeta/transforms/target_transforms.py
+++ b/torchmeta/transforms/target_transforms.py
@@ -1,0 +1,21 @@
+class TargetTransform(object):
+    def __call__(self, target):
+        raise NotImplementedError()
+
+    def __repr__(self):
+        return str(self.__class__.__name__)
+
+
+class DefaultTargetTransform(TargetTransform):
+    def __init__(self, class_augmentations):
+        super(DefaultTargetTransform, self).__init__()
+        self.class_augmentations = class_augmentations
+        
+        self._augmentations = dict((augmentation, i + 1)
+            for (i, augmentation) in enumerate(class_augmentations))
+        self._augmentations[None] = 0
+
+    def __call__(self, target):
+        assert isinstance(target, tuple) and len(target) == 2
+        label, augmentation = target
+        return (label, self._augmentations[augmentation])

--- a/torchmeta/utils/data/dataset.py
+++ b/torchmeta/utils/data/dataset.py
@@ -6,7 +6,7 @@ from itertools import combinations
 from torchvision.transforms import Compose
 
 from torchmeta.utils.data.task import ConcatTask
-from torchmeta.transforms import FixedCategory, Categorical
+from torchmeta.transforms import FixedCategory, Categorical, DefaultTargetTransform
 from torchmeta.transforms.utils import wrap_transform
 
 __all__ = ['ClassDataset', 'MetaDataset', 'CombinationMetaDataset']
@@ -243,6 +243,12 @@ class CombinationMetaDataset(MetaDataset):
                 '`int`, got `{0}`.'.format(type(num_classes_per_task)))
         self.dataset = dataset
         self.num_classes_per_task = num_classes_per_task
+        # If no target_transform, then use a default target transform that
+        # is well behaved for the `default_collate` function (assign class
+        # augmentations ot integers).
+        if target_transform is None:
+            target_transform = DefaultTargetTransform(dataset.class_augmentations)
+
         super(CombinationMetaDataset, self).__init__(meta_train=dataset.meta_train,
             meta_val=dataset.meta_val, meta_test=dataset.meta_test,
             meta_split=dataset.meta_split, target_transform=target_transform,


### PR DESCRIPTION
 - Use a default `target_transform` which is well-behaved for the `default_collate` function (i.e. which converts class augmentations to integers)
 - Addresses #27 @tesfaldet 