### PR TITLE
Add support for DataParallel

### DIFF
--- a/docs/api_reference/modules.md
+++ b/docs/api_reference/modules.md
@@ -106,3 +106,13 @@ torchmeta.modules.MetaLayerNorm(normalized_shape, eps=1e-05,
 
 !!! note "Notes"
     See: `torch.nn.LayerNorm`
+
+## DataParallel
+
+```python
+torchmeta.modules.DataParallel(module, device_ids=None, output_device=None,
+    dim=0)
+```
+
+!!! note "Notes"
+    See: `torch.nn.Parallel`

--- a/torchmeta/modules/__init__.py
+++ b/torchmeta/modules/__init__.py
@@ -4,6 +4,7 @@ from torchmeta.modules.conv import MetaConv1d, MetaConv2d, MetaConv3d
 from torchmeta.modules.linear import MetaLinear, MetaBilinear
 from torchmeta.modules.module import MetaModule
 from torchmeta.modules.normalization import MetaLayerNorm
+from torchmeta.modules.parallel import DataParallel
 
 __all__ = [
     'MetaBatchNorm1d', 'MetaBatchNorm2d', 'MetaBatchNorm3d',
@@ -11,5 +12,6 @@ __all__ = [
     'MetaConv1d', 'MetaConv2d', 'MetaConv3d',
     'MetaLinear', 'MetaBilinear',
     'MetaModule',
-    'MetaLayerNorm'
+    'MetaLayerNorm',
+    'DataParallel'
 ]

--- a/torchmeta/modules/parallel.py
+++ b/torchmeta/modules/parallel.py
@@ -16,5 +16,5 @@ class DataParallel(DataParallel_, MetaModule):
 
         inputs_, kwargs_ = scatter_kwargs(inputs, kwargs, device_ids, dim=self.dim)
         # Add params argument unchanged back in kwargs
-        kwargs_ = tuple(k.update(params=params) for k in kwargs_)
+        kwargs_ = tuple(dict(params=params, **k) for k in kwargs_)
         return inputs_, kwargs_

--- a/torchmeta/modules/parallel.py
+++ b/torchmeta/modules/parallel.py
@@ -1,8 +1,11 @@
+import torch
 from torch.nn import DataParallel as DataParallel_
 from torchmeta.modules.module import MetaModule
+from collections import OrderedDict
 
 from torch.nn.parallel import parallel_apply
 from torch.nn.parallel.scatter_gather import scatter_kwargs
+from torch.nn.parallel.replicate import _broadcast_coalesced_reshape
 
 
 class DataParallel(DataParallel_, MetaModule):
@@ -16,5 +19,19 @@ class DataParallel(DataParallel_, MetaModule):
 
         inputs_, kwargs_ = scatter_kwargs(inputs, kwargs, device_ids, dim=self.dim)
         # Add params argument unchanged back in kwargs
-        kwargs_ = tuple(dict(params=params, **k) for k in kwargs_)
+        replicas = self._replicate_params(params, inputs_, device_ids,
+                                          detach=not torch.is_grad_enabled())
+        kwargs_ = tuple(dict(params=replica, **kwarg)
+                        for (kwarg, replica) in zip(kwargs_, replicas))
         return inputs_, kwargs_
+
+    def _replicate_params(self, params, inputs, device_ids, detach=False):
+        if params is None:
+            return tuple(None for _ in inputs)
+
+        replicas = _broadcast_coalesced_reshape(list(params.values()),
+                                                device_ids[:len(inputs)],
+                                                detach)
+        replicas = tuple(OrderedDict(zip(params.keys(), replica))
+                         for replica in replicas)
+        return replicas

--- a/torchmeta/modules/parallel.py
+++ b/torchmeta/modules/parallel.py
@@ -1,0 +1,20 @@
+from torch.nn import DataParallel as DataParallel_
+from torchmeta.modules.module import MetaModule
+
+from torch.nn.parallel import parallel_apply
+from torch.nn.parallel.scatter_gather import scatter_kwargs
+
+
+class DataParallel(DataParallel_, MetaModule):
+    __doc__ = DataParallel_.__doc__
+
+    def scatter(self, inputs, kwargs, device_ids):
+        try:
+            params = kwargs.pop('params')
+        except KeyError:
+            return super(DataParallel, self).scatter(inputs, kwargs, device_ids)
+
+        inputs_, kwargs_ = scatter_kwargs(inputs, kwargs, device_ids, dim=self.dim)
+        # Add params argument unchanged back in kwargs
+        kwargs_ = tuple(k.update(params=params) for k in kwargs_)
+        return inputs_, kwargs_

--- a/torchmeta/modules/utils.py
+++ b/torchmeta/modules/utils.py
@@ -4,8 +4,14 @@ from collections import OrderedDict
 def get_subdict(dictionary, key=None):
     if dictionary is None:
         return None
+
     if (key is None) or (key == ''):
         return dictionary
+
     key_re = re.compile(r'^{0}\.(.+)'.format(re.escape(key)))
+    # Compatibility with DataParallel
+    if not any(filter(key_re.match, dictionary.keys())):
+        key_re = re.compile(r'^module\.{0}\.(.+)'.format(re.escape(key)))
+
     return OrderedDict((key_re.sub(r'\1', k), value) for (k, value)
         in dictionary.items() if key_re.match(k) is not None)

--- a/torchmeta/tests/test_dataparallel.py
+++ b/torchmeta/tests/test_dataparallel.py
@@ -1,0 +1,58 @@
+import pytest
+
+import torch
+import torch.nn as nn
+
+from torchmeta.modules import MetaLinear, MetaSequential
+from torchmeta.modules import DataParallel
+
+is_multi_gpu = (torch.cuda.device_count() > 1)
+
+@pytest.fixture
+def model():
+    model = MetaSequential(
+        MetaLinear(2, 3, bias=True),
+        nn.ReLU(),
+        MetaLinear(3, 1, bias=False))
+
+    return model
+
+@pytest.fixture
+def params():
+    device = torch.device('cuda:0')
+    weight_0 = torch.tensor([
+        [0.02, 0.03],
+        [0.05, 0.07],
+        [0.11, 0.13]], device=device, dtype=torch.float32)
+    bias_0 = torch.tensor([0.17, 0.19, 0.23],
+                          device=device, dtype=torch.float32)
+    weight_2 = torch.tensor([[0.29, 0.31, 0.37]],
+                            device=device, dtype=torch.float32)
+
+    return {'0.weight': weight_0, '0.bias': bias_0, '2.weight': weight_2}
+
+
+@pytest.mark.skipif(not is_multi_gpu, reason='Requires Multi-GPU support')
+def test_dataparallel(model):
+    device = torch.device('cuda:0')
+    model = DataParallel(model)
+    model.to(device=device)
+
+    inputs = torch.rand(5, 2).to(device=device)
+    outputs = model(inputs)
+
+    assert outputs.shape == (5, 1)
+    assert outputs.device == device
+
+
+@pytest.mark.skipif(not is_multi_gpu, reason='Requires Multi-GPU support')
+def test_dataparallel_params(model, params):
+    device = torch.device('cuda:0')
+    model = DataParallel(model)
+    model.to(device=device)
+
+    inputs = torch.rand(5, 2).to(device=device)
+    outputs = model(inputs, params=params)
+
+    assert outputs.shape == (5, 1)
+    assert outputs.device == device


### PR DESCRIPTION
 - Add `DataParallel` meta-module in `torchmeta.modules`. This is identical to `torch.nn.DataParallel`, with full support for operations on `MetaModule` instances (pass additional `params` argument in `forward()`, access to `meta_parameters()`/`meta_named_parameters()` methods)
 - Add tests for `DataParallel`, conditional on multi-GPU support
 - Fixes #43 