### PR TITLE
Remove version requirement from h5py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         'torchvision>=0.5.0,<0.7.0',
         'numpy>=1.14.0',
         'Pillow>=7.0.0',
-        'h5py~=2.9.0',
+        'h5py',
         'tqdm>=4.0.0',
         'requests' # Required by Torchvision
     ],


### PR DESCRIPTION
I needed to do this in order to pip install TorchMeta on Mac OS X (python 3.8.2 installed with conda).