### PR TITLE
Fix calls for len(CombinationRandomSampler)

### DIFF
--- a/torchmeta/utils/data/sampler.py
+++ b/torchmeta/utils/data/sampler.py
@@ -23,7 +23,7 @@ class CombinationRandomSampler(RandomSampler):
     def __init__(self, data_source):
         if not isinstance(data_source, CombinationMetaDataset):
             raise ValueError()
-        self.data_source = data_source
+        super(CombinationRandomSampler, self).__init__(data_source)
 
     def __iter__(self):
         num_classes = len(self.data_source.dataset)

--- a/torchmeta/utils/data/sampler.py
+++ b/torchmeta/utils/data/sampler.py
@@ -10,7 +10,9 @@ __all__ = ['CombinationSequentialSampler', 'CombinationRandomSampler']
 class CombinationSequentialSampler(SequentialSampler):
     def __init__(self, data_source):
         if not isinstance(data_source, CombinationMetaDataset):
-            raise ValueError()
+            raise TypeError('Expected `data_source` to be an instance of '
+                            '`CombinationMetaDataset`, but found '
+                            '{0}'.format(type(data_source)))
         super(CombinationSequentialSampler, self).__init__(data_source)
 
     def __iter__(self):
@@ -22,7 +24,9 @@ class CombinationSequentialSampler(SequentialSampler):
 class CombinationRandomSampler(RandomSampler):
     def __init__(self, data_source):
         if not isinstance(data_source, CombinationMetaDataset):
-            raise ValueError()
+            raise TypeError('Expected `data_source` to be an instance of '
+                            '`CombinationMetaDataset`, but found '
+                            '{0}'.format(type(data_source)))
         super(CombinationRandomSampler, self).__init__(data_source)
 
     def __iter__(self):


### PR DESCRIPTION
Closes https://github.com/tristandeleu/pytorch-meta/issues/52

I have also changed the error type when passing a `data_source` that is not a `CombinationMetaDataset` to a `CombinationSampler` from `ValueError` to `TypeError`, and added error messages for them.