### PR TITLE
Children modules parameter names caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: python
 python:
-  - "3.5"
   - "3.6"
   - "3.7"
+  - "3.8"
 install:
   - pip install .
 script:

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ source venv/bin/activate
 ```
 
 #### Requirements
- - Python 3.5 or above
+ - Python 3.6 or above
  - PyTorch 1.3 or above
  - Torchvision 0.4 or above
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,7 +34,7 @@ source venv/bin/activate
 ```
 
 #### Requirements
- - Python 3.5 or above
+ - Python 3.6 or above
  - PyTorch 1.3 or above
  - Torchvision 0.4 or above
 

--- a/examples/anil/model.py
+++ b/examples/anil/model.py
@@ -1,6 +1,6 @@
 import torch.nn as nn
 from torchmeta.modules import MetaModule, MetaLinear
-from torchmeta.modules.utils import get_subdict
+
 
 def conv3x3(in_channels, out_channels, **kwargs):
     # The convolutional layers (for feature extraction) use standard layers from
@@ -33,5 +33,5 @@ class ConvolutionalNeuralNetwork(MetaModule):
     def forward(self, inputs, params=None):
         features = self.features(inputs)
         features = features.view((features.size(0), -1))
-        logits = self.classifier(features, params=get_subdict(params, 'classifier'))
+        logits = self.classifier(features, params=self.get_subdict(params, 'classifier'))
         return logits

--- a/examples/maml/model.py
+++ b/examples/maml/model.py
@@ -1,7 +1,7 @@
 import torch.nn as nn
 from torchmeta.modules import (MetaModule, MetaSequential, MetaConv2d,
                                MetaBatchNorm2d, MetaLinear)
-from torchmeta.modules.utils import get_subdict
+
 
 def conv3x3(in_channels, out_channels, **kwargs):
     return MetaSequential(
@@ -28,7 +28,7 @@ class ConvolutionalNeuralNetwork(MetaModule):
         self.classifier = MetaLinear(hidden_size, out_features)
 
     def forward(self, inputs, params=None):
-        features = self.features(inputs, params=get_subdict(params, 'features'))
+        features = self.features(inputs, params=self.get_subdict(params, 'features'))
         features = features.view((features.size(0), -1))
-        logits = self.classifier(features, params=get_subdict(params, 'classifier'))
+        logits = self.classifier(features, params=self.get_subdict(params, 'classifier'))
         return logits

--- a/setup.py
+++ b/setup.py
@@ -47,9 +47,9 @@ setup(
         'Topic :: Scientific/Engineering :: Artificial Intelligence',
         'Intended Audience :: Science/Research',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'License :: OSI Approved :: MIT License',
     ],
 )

--- a/torchmeta/modules/container.py
+++ b/torchmeta/modules/container.py
@@ -1,7 +1,7 @@
 import torch.nn as nn
 
 from torchmeta.modules.module import MetaModule
-from torchmeta.modules.utils import get_subdict
+
 
 class MetaSequential(nn.Sequential, MetaModule):
     __doc__ = nn.Sequential.__doc__
@@ -9,7 +9,7 @@ class MetaSequential(nn.Sequential, MetaModule):
     def forward(self, input, params=None):
         for name, module in self._modules.items():
             if isinstance(module, MetaModule):
-                input = module(input, params=get_subdict(params, name))
+                input = module(input, params=self.get_subdict(params, name))
             elif isinstance(module, nn.Module):
                 input = module(input)
             else:

--- a/torchmeta/modules/module.py
+++ b/torchmeta/modules/module.py
@@ -1,7 +1,9 @@
 import torch
 import torch.nn as nn
+import re
 
 from collections import OrderedDict
+
 
 class MetaModule(nn.Module):
     """
@@ -14,6 +16,10 @@ class MetaModule(nn.Module):
     modules from `torch.nn.Module`. The argument `params` is a dictionary of
     tensors, with full support of the computation graph (for differentiation).
     """
+    def __init__(self):
+        super(MetaModule, self).__init__()
+        self._children_modules_parameters_cache = dict()
+
     def meta_named_parameters(self, prefix='', recurse=True):
         gen = self._named_members(
             lambda module: module._parameters.items()
@@ -25,3 +31,25 @@ class MetaModule(nn.Module):
     def meta_parameters(self, recurse=True):
         for name, param in self.meta_named_parameters(recurse=recurse):
             yield param
+
+    def get_subdict(self, params, key=None):
+        if params is None:
+            return None
+
+        all_names = tuple(params.keys())
+        if (key, all_names) not in self._children_modules_parameters_cache:
+            if key is None:
+                self._children_modules_parameters_cache[(key, all_names)] = all_names
+
+            key_escape = re.escape(key)
+            key_re = re.compile(r'^{0}\.(.+)'.format(key_escape))
+            # Compatibility with DataParallel
+            if not any(filter(key_re.match, all_names)):
+                key_re = re.compile(r'^module\.{0}\.(.+)'.format(key_escape))
+
+            self._children_modules_parameters_cache[(key, all_names)] = [
+                key_re.sub(r'\1', k) for k in all_names if key_re.match(k) is not None]
+
+        names = self._children_modules_parameters_cache[(key, all_names)]
+
+        return OrderedDict([(name, params[f'{key}.{name}']) for name in names])

--- a/torchmeta/modules/utils.py
+++ b/torchmeta/modules/utils.py
@@ -1,7 +1,14 @@
 import re
+import warnings
+
 from collections import OrderedDict
 
 def get_subdict(dictionary, key=None):
+    warnings.warn('The function `torchmeta.modules.utils.get_subdict` is '
+                  'deprecated, and will be removed in Torchmeta v1.5. Please '
+                  'use the `get_subdict` method from `MetaModule` (e.g. '
+                  '`self.get_subdict(params, "{0}")`) instead.'.format(key),
+                  stacklevel=2)
     if dictionary is None:
         return None
 

--- a/torchmeta/version.py
+++ b/torchmeta/version.py
@@ -1,1 +1,1 @@
-VERSION = '1.4.5'
+VERSION = '1.4.6'


### PR DESCRIPTION
 - Add a cache in `MetaModule` for the names of the parameters of children modules.
 - Add the `get_subdict` method to `MetaModule`. This new method replaces `torchmeta.modules.utils.get_subdict`, which will be deprecated in Torchmeta 1.5. Here is an example of how to update you custom `MetaModule`:

```diff
diff --git a/examples/maml/model.py b/examples/maml/model.py
index dad59ba..07ab5ce 100644
--- a/examples/maml/model.py
+++ b/examples/maml/model.py
@@ -1,7 +1,7 @@
 import torch.nn as nn
 from torchmeta.modules import (MetaModule, MetaSequential, MetaConv2d,
                                MetaBatchNorm2d, MetaLinear)
-from torchmeta.modules.utils import get_subdict
+

 def conv3x3(in_channels, out_channels, **kwargs):
     return MetaSequential(
@@ -28,7 +28,7 @@ class ConvolutionalNeuralNetwork(MetaModule):
         self.classifier = MetaLinear(hidden_size, out_features)

     def forward(self, inputs, params=None):
-        features = self.features(inputs, params=get_subdict(params, 'features'))
+        features = self.features(inputs, params=self.get_subdict(params, 'features'))
         features = features.view((features.size(0), -1))
-        logits = self.classifier(features, params=get_subdict(params, 'classifier'))
+        logits = self.classifier(features, params=self.get_subdict(params, 'classifier'))
         return logits
```