### PR TITLE
change: added seed as an argument of dataset to enable reproducibility

### DIFF
--- a/torchmeta/toy/harmonic.py
+++ b/torchmeta/toy/harmonic.py
@@ -33,6 +33,9 @@ class Harmonic(MetaDataset):
         A function/transform that takes a dataset (ie. a task), and returns a 
         transformed version of it. E.g. `torchmeta.transforms.ClassSplitter()`.
 
+    seed : int
+        Used to set the seed of the numpy random generator.
+
     Notes
     -----
     The tasks are created randomly as the sum of two sinusoid functions, with
@@ -50,9 +53,9 @@ class Harmonic(MetaDataset):
     """
     def __init__(self, num_samples_per_task, num_tasks=5000,
                  noise_std=None, transform=None, target_transform=None,
-                 dataset_transform=None):
+                 dataset_transform=None, seed=None):
         super(Harmonic, self).__init__(meta_split='train',
-            target_transform=target_transform, dataset_transform=dataset_transform)
+            target_transform=target_transform, dataset_transform=dataset_transform, seed=seed)
         self.num_samples_per_task = num_samples_per_task
         self.num_tasks = num_tasks
         self.noise_std = noise_std

--- a/torchmeta/toy/sinusoid.py
+++ b/torchmeta/toy/sinusoid.py
@@ -31,6 +31,9 @@ class Sinusoid(MetaDataset):
         A function/transform that takes a dataset (ie. a task), and returns a 
         transformed version of it. E.g. `torchmeta.transforms.ClassSplitter()`.
 
+    seed : int
+        Used to set the seed of the numpy random generator.
+
     Notes
     -----
     The tasks are created randomly as random sinusoid function. The amplitude
@@ -47,9 +50,9 @@ class Sinusoid(MetaDataset):
     """
     def __init__(self, num_samples_per_task, num_tasks=1000000,
                  noise_std=None, transform=None, target_transform=None,
-                 dataset_transform=None):
+                 dataset_transform=None, seed=None):
         super(Sinusoid, self).__init__(meta_split='train',
-            target_transform=target_transform, dataset_transform=dataset_transform)
+            target_transform=target_transform, dataset_transform=dataset_transform, seed=seed)
         self.num_samples_per_task = num_samples_per_task
         self.num_tasks = num_tasks
         self.noise_std = noise_std

--- a/torchmeta/toy/sinusoid_line.py
+++ b/torchmeta/toy/sinusoid_line.py
@@ -34,6 +34,9 @@ class SinusoidAndLine(MetaDataset):
         A function/transform that takes a dataset (ie. a task), and returns a 
         transformed version of it. E.g. `torchmeta.transforms.ClassSplitter()`.
 
+    seed : int
+        Used to set the seed of the numpy random generator.
+
     Notes
     -----
     The tasks are created randomly as either random sinusoid functions, or
@@ -52,9 +55,9 @@ class SinusoidAndLine(MetaDataset):
     """
     def __init__(self, num_samples_per_task, num_tasks=1000000,
                  noise_std=None, transform=None, target_transform=None,
-                 dataset_transform=None):
+                 dataset_transform=None, seed=None):
         super(SinusoidAndLine, self).__init__(meta_split='train',
-            target_transform=target_transform, dataset_transform=dataset_transform)
+            target_transform=target_transform, dataset_transform=dataset_transform, seed=seed)
         self.num_samples_per_task = num_samples_per_task
         self.num_tasks = num_tasks
         self.noise_std = noise_std

--- a/torchmeta/utils/data/dataset.py
+++ b/torchmeta/utils/data/dataset.py
@@ -158,9 +158,13 @@ class MetaDataset(object):
     dataset_transform : callable, optional
         A function/transform that takes a dataset (ie. a task), and returns a 
         transformed version of it. E.g. `transforms.ClassSplitter()`.
+
+    seed : int
+        Used to set the seed of the numpy random generator.
+
     """
     def __init__(self, meta_train=False, meta_val=False, meta_test=False,
-                 meta_split=None, target_transform=None, dataset_transform=None):
+                 meta_split=None, target_transform=None, dataset_transform=None, seed=None):
         if meta_train + meta_val + meta_test == 0:
             if meta_split is None:
                 raise ValueError('The meta-split is undefined. Use either the '
@@ -182,7 +186,7 @@ class MetaDataset(object):
         self._meta_split = meta_split
         self.target_transform = target_transform
         self.dataset_transform = dataset_transform
-        self.seed()
+        self.seed(seed)
 
     @property
     def meta_split(self):
@@ -238,9 +242,13 @@ class CombinationMetaDataset(MetaDataset):
     dataset_transform : callable, optional
         A function/transform that takes a dataset (ie. a task), and returns a 
         transformed version of it. E.g. `transforms.ClassSplitter()`.
+
+    seed : int
+        Used to set the seed of the numpy random generator.
+
     """
     def __init__(self, dataset, num_classes_per_task, target_transform=None,
-                 dataset_transform=None):
+                 dataset_transform=None, seed=None):
         if not isinstance(num_classes_per_task, int):
             raise TypeError('Unknown type for `num_classes_per_task`. Expected '
                 '`int`, got `{0}`.'.format(type(num_classes_per_task)))
@@ -255,7 +263,7 @@ class CombinationMetaDataset(MetaDataset):
         super(CombinationMetaDataset, self).__init__(meta_train=dataset.meta_train,
             meta_val=dataset.meta_val, meta_test=dataset.meta_test,
             meta_split=dataset.meta_split, target_transform=target_transform,
-            dataset_transform=dataset_transform)
+            dataset_transform=dataset_transform, seed=seed)
 
     def __iter__(self):
         num_classes = len(self.dataset)


### PR DESCRIPTION
In the init of the `MetaDataset` class there was the call to `self.seed()` but actually hadn't had an effect so far.
I added a parameter and altered the call of the seed function in the `__init__()`.

I would appreciate accepting the pull request or telling me how to set the seed otherwise, I really don't get it :sweat_smile: