### PR TITLE
Fix/multi head attention

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ source venv/bin/activate
 
 #### Requirements
  - Python 3.6 or above
- - PyTorch 1.4 or above
+ - PyTorch 1.9 or above
  - Torchvision 0.5 or above
 
 #### Using pip

--- a/torchmeta/modules/activation.py
+++ b/torchmeta/modules/activation.py
@@ -29,6 +29,9 @@ class MetaMultiheadAttention(nn.MultiheadAttention, MetaModule):
         bias_k = params.get('bias_k', None)
         bias_v = params.get('bias_v', None)
 
+        if self.batch_first:
+            query, key, value = [x.transpose(1, 0) for x in (query, key, value)]
+
         if not self._qkv_same_embed_dim:
             attn_output, attn_output_weights = F.multi_head_attention_forward(
                 query, key, value, self.embed_dim, self.num_heads,


### PR DESCRIPTION
In the `MetaMultiheadAttention` class, for a `batch_first` case, the code corresponding to **pre-transpose** is missing. Additionally, as the `batch_first` argument has been used in `nn.MultiHeadAttention` from PyTorch 1.9, I updated the `README.md` accordingly.

### Refrerence
[PyTorch 1.9](https://github.com/pytorch/pytorch/blob/dfbd030854359207cb3040b864614affeace11ce/torch/nn/modules/activation.py#L1016)
[PyTorch 2.0](https://github.com/pytorch/pytorch/blob/750b9b359f06cb8b8c2d5b6118bba636e2112cbb/torch/nn/modules/activation.py#L1206)
